### PR TITLE
Chore/live api dev in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,18 @@ RUN apt-get remove -y python-cffi
 
 
 ADD . /srv/caliopen/api
-WORKDIR /srv/caliopen/api/
+WORKDIR /srv/caliopen/
 
 # Install the source in the /srv/caliopen/api
 RUN pip install bcrypt
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.user.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.message.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.api.base.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.api.user.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.api.message.git
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.git#egg=caliopen.base
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.user.git#egg=caliopen.base.user
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.message.git#egg=caliopen.base.message
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.api.base.git#egg=caliopen.api.base
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.api.user.git#egg=caliopen.api.user
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.api.message.git#egg=caliopen.api.message
+
+WORKDIR /srv/caliopen/api/
 RUN python setup.py develop
 
 RUN useradd docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ MAINTAINER Caliopen
 ENV DEBIAN_FRONTEND noninteractive
 
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
+RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y python python-dev python-pip git libffi-dev
 RUN pip install -U pip     # use a decent version


### PR DESCRIPTION
install caliopen packages as editable

This allows caliopen-dev to start in full dev mode

**Requires:** 

* #4 